### PR TITLE
Add buffer-size to uwsgi.ini to fix OAuth callback 502 errors

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -14,3 +14,4 @@ gid = nginx
 env = HOME=/home/nginx
 cheaper = 0
 processes = 1
+buffer-size = 32768


### PR DESCRIPTION
## Summary

- The default uWSGI buffer-size of 4096 bytes is too small for some OAuth callback requests, which include state, code, scope, authuser, and other query parameters totaling ~4400 bytes. This causes uWSGI to reject the request with "invalid request block size", resulting in a 502 Bad Gateway from nginx.
- Sets buffer-size to 32768 to add more than sufficient room.